### PR TITLE
Fixed policy in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ vault login "root"
 Write a dev policy file 
 
 ```bash
-echo 'path "secret/data/example" {
+echo 'path "secret/example" {
   capabilities = ["read", "list"]
 }' > dev.hcl
 ```


### PR DESCRIPTION
The policy won't work as expected with latest versions with Vault if it has "data". It was a requirement early on with the new kv, not anymore.